### PR TITLE
Fix JSON property check

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         // Listen for messages
         socket.addEventListener( 'message', function( event ) {
                 var event = JSON.parse( event.data );
-                if ( !event[ 2 ] || !event[ 2 ].kind ) return;
+                if ( !event[ 2 ] || !event[ 2 ].hasOwnProperty('kind') ) return;
                 if ( event[ 2 ].kind == 4 ) {
                         var i; for ( i=0; i<event[ 2 ].tags.length; i++ ) {
                                         if ( event[ 2 ].tags[ i ] && event[ 2 ].tags[ i ][ 1 ] ) {


### PR DESCRIPTION
The previous version didn't work with kind 0 events, not sure why.

Probably because `event[ 2 ].kind` was evaluated to 0, so false, causing `if ( !event[ 2 ] || !event[ 2 ].kind ) return;` to return.